### PR TITLE
Fix the export in CommonJS environments

### DIFF
--- a/lib/json3.js
+++ b/lib/json3.js
@@ -3,10 +3,26 @@
   // Convenience aliases.
   var getClass = {}.toString, isProperty, forEach, undef;
 
-  // Detect the `define` function exposed by asynchronous module loaders and set
-  // up the internal `JSON3` namespace. The strict equality check for `define`
-  // is necessary for compatibility with the RequireJS optimizer (`r.js`).
-  var isLoader = typeof define === "function" && define.amd, JSON3 = typeof exports == "object" && exports;
+  var JSON3 = {};
+  // Export the JSON 3 for CommonJS environments, asynchronous module
+  // loaders, browsers, and JavaScript engines.
+  if (typeof module !== "undefined") {
+    // Node style
+    module.exports = JSON3;
+  } else if (typeof exports !== "undefined") {
+    // Node style, but only the exports object is available
+    JSON3 = exports;
+  } else if (typeof define === "function" && define.amd) {
+    define("json", JSON3);
+  } else {
+    this.JSON = JSON3 = {};
+  }
+
+  // If possible, use the existing JSON object as baseline
+  if (typeof JSON == "object" && JSON) {
+    JSON3.stringify = JSON.stringify;
+    JSON3.parse = JSON.parse;
+  }
 
   // A JSON source string used to test the native `stringify` and `parse`
   // implementations.
@@ -42,26 +58,6 @@
       return Months[month] + 365 * (year - 1970) + floor((year - 1969 + (month = +(month > 1))) / 4) - floor((year - 1901 + month) / 100) + floor((year - 1601 + month) / 400);
     };
   }
-
-  // Export JSON 3 for asynchronous module loaders, CommonJS environments, web
-  // browsers, and JavaScript engines. Credits: Oyvind Sean Kinsey.
-  if (isLoader || JSON3) {
-    if (isLoader) {
-      // Export for asynchronous module loaders. The `JSON3` namespace is
-      // redefined because module loaders do not provide the `exports` object.
-      define("json", (JSON3 = {}));
-    }
-    if (typeof JSON == "object" && JSON) {
-      // Delegate to the native `stringify` and `parse` implementations in
-      // asynchronous module loaders and CommonJS environments.
-      JSON3.stringify = JSON.stringify;
-      JSON3.parse = JSON.parse;
-    }
-  } else {
-    // Export for browsers and JavaScript engines.
-    JSON3 = this.JSON || (this.JSON = {});
-  }
-
   // Test `JSON.stringify`.
   if ((stringifySupported = typeof JSON3.stringify == "function" && !getDay)) {
     // A test function object with a custom `toJSON` method.


### PR DESCRIPTION
Summary:
If the current module is used in a mixed environment, loaded as part of
a CommonJS style module, but where the scopechain contains an AMD style
'defined' function, this function would wrongfully use this to define
itself instead of exporting using the module/exports variables.

This diff changes the order of the tests so that it prefers exporting to
the `module` object, then the `exports` object and finally using `define`.

Test Plan: Ran the test suite, and loaded the module inside a local
CommonJS environment running in a page also hosting an AMD style loader.

Reviewers: kitcambridge
