### PR TITLE
Have json3 behave as a shim in browsers even if loaded with require

### DIFF
--- a/lib/json3.js
+++ b/lib/json3.js
@@ -51,7 +51,7 @@
       // redefined because module loaders do not provide the `exports` object.
       define("json", (JSON3 = {}));
     }
-    if (typeof JSON == "object") {
+    if (typeof JSON == "object" && JSON) {
       // Delegate to the native `stringify` and `parse` implementations in
       // asynchronous module loaders and CommonJS environments.
       JSON3.stringify = JSON.stringify;


### PR DESCRIPTION
The problem I'm trying to solve is simple.
I want json3 to behave uniformly as a shim in browsers (that is: patch/populate window.JSON if needed), independently of the way it is loaded.

Currently:
- if the browser doesn't have native JSON support, and json3.js is loaded in a script tag or with any other (non AMD) loader, that's ok (eg: window.JSON == JSON3)

But:
- if the browser doesn't have native JSON support, and json3.js is loaded with requirejs (or I assume any other AMD loader), it is exported only as a module, and doesn't populate window.JSON

Libraries that are willing to provide functionality relying on JSON (without explicitly requiring AMD) would then have to do their own guessing ("if amd then require json else window.JSON"), which is not good IMHO.

This patch tries to fix this shortcoming.

I hope this is cautious enough to not mess-up other (non-browser) environments, but admittedly I'm not familiar with them.

Thanks!

Regards,
- Olivier
