### PR TITLE
fix loading when both `define` and `exports` exist

### DIFF
--- a/lib/json3.js
+++ b/lib/json3.js
@@ -5,17 +5,17 @@
 
   // Detect the `define` function exposed by asynchronous module loaders. The
   // strict `define` check is necessary for compatibility with `r.js`.
-  var isLoader = typeof define === "function" && define.amd, JSON3 = !isLoader && typeof exports == "object" && exports;
+  var isLoader = typeof define === "function" && define.amd, JSON3 = typeof exports == "object" && exports;
 
   if (JSON3 || isLoader) {
     if (typeof JSON == "object" && JSON) {
       // Delegate to the native `stringify` and `parse` implementations in
       // asynchronous module loaders and CommonJS environments.
-      if (isLoader) {
-        JSON3 = JSON;
-      } else {
+      if (JSON3) {
         JSON3.stringify = JSON.stringify;
         JSON3.parse = JSON.parse;
+      } else {
+        JSON3 = JSON;
       }
     } else if (isLoader) {
       JSON3 = window.JSON = {};


### PR DESCRIPTION
We ran into problems when users tried to use [mapbox.js](https://github.com/mapbox/mapbox.js), which uses browserify, on a site with requirejs. Since `define` was defined, nothing was added to `exports`.

With this change, if both `define` and `exports` are present it will load it with both systems.
