### PR TITLE
Fixed some warnings uglifyjs gave when compressing.

### DIFF
--- a/lib/json3.js
+++ b/lib/json3.js
@@ -644,7 +644,7 @@
 
       // Internal: Parses a JSON `value` token.
       get = function (value) {
-        var results, any, key;
+        var results, any;
         if (value == "$") {
           // Unexpected end of input.
           abort();


### PR DESCRIPTION
"uglifyjs --lint -c json3.js" should ideally do its thing without noting any warnings like unused variables & etc.
