### PR TITLE
Add .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+coverage
+test
+.travis.yml


### PR DESCRIPTION
We don't need Travis, Coverage, or Tests in the published npm package.