### PR TITLE
Add a body to for() loops to fix Google closure warnings

### DIFF
--- a/lib/json3.js
+++ b/lib/json3.js
@@ -265,7 +265,7 @@
               }
             }
             // Manually invoke the callback for each non-enumerable property.
-            for (length = members.length; property = members[--length]; hasProperty.call(object, property) && callback(property));
+            for (length = members.length; property = members[--length]; hasProperty.call(object, property) && callback(property)){}
           };
         } else {
           // No bugs detected; use the standard `for...in` algorithm.
@@ -332,8 +332,8 @@
               // seconds, and milliseconds if the `getUTC*` methods are
               // buggy. Adapted from @Yaffle's `date-shim` project.
               date = floor(value / 864e5);
-              for (year = floor(date / 365.2425) + 1970 - 1; getDay(year + 1, 0) <= date; year++);
-              for (month = floor((date - getDay(year, 0)) / 30.42); getDay(year, month + 1) <= date; month++);
+              for (year = floor(date / 365.2425) + 1970 - 1; getDay(year + 1, 0) <= date; year++){}
+              for (month = floor((date - getDay(year, 0)) / 30.42); getDay(year, month + 1) <= date; month++){}
               date = 1 + date - getDay(year, month);
               // The `time` value specifies the time within the day (see ES
               // 5.1 section 15.9.1.2). The formula `(A % B + B) % B` is used
@@ -525,7 +525,7 @@
               } else if (className == arrayClass) {
                 // Convert the property names array into a makeshift set.
                 properties = {};
-                for (var index = 0, length = filter.length, value; index < length; value = filter[index++], ((className = getClass.call(value)), className == stringClass || className == numberClass) && (properties[value] = 1));
+                for (var index = 0, length = filter.length, value; index < length; value = filter[index++], ((className = getClass.call(value)), className == stringClass || className == numberClass) && (properties[value] = 1)){}
               }
             }
             if (width) {
@@ -534,7 +534,7 @@
                 // Convert the `width` to an integer and create a string containing
                 // `width` number of space characters.
                 if ((width -= width % 1) > 0) {
-                  for (whitespace = "", width > 10 && (width = 10); whitespace.length < width; whitespace += " ");
+                  for (whitespace = "", width > 10 && (width = 10); whitespace.length < width; whitespace += " "){}
                 }
               } else if (className == stringClass) {
                 whitespace = width.length <= 10 ? width : width.slice(0, 10);
@@ -676,13 +676,13 @@
                   }
                   isSigned = false;
                   // Parse the integer component.
-                  for (; Index < length && ((charCode = source.charCodeAt(Index)), charCode >= 48 && charCode <= 57); Index++);
+                  for (; Index < length && ((charCode = source.charCodeAt(Index)), charCode >= 48 && charCode <= 57); Index++){}
                   // Floats cannot contain a leading decimal point; however, this
                   // case is already accounted for by the parser.
                   if (source.charCodeAt(Index) == 46) {
                     position = ++Index;
                     // Parse the decimal component.
-                    for (; position < length && ((charCode = source.charCodeAt(position)), charCode >= 48 && charCode <= 57); position++);
+                    for (; position < length && ((charCode = source.charCodeAt(position)), charCode >= 48 && charCode <= 57); position++){}
                     if (position == Index) {
                       // Illegal trailing decimal.
                       abort();
@@ -700,7 +700,7 @@
                       Index++;
                     }
                     // Parse the exponential component.
-                    for (position = Index; position < length && ((charCode = source.charCodeAt(position)), charCode >= 48 && charCode <= 57); position++);
+                    for (position = Index; position < length && ((charCode = source.charCodeAt(position)), charCode >= 48 && charCode <= 57); position++){}
                     if (position == Index) {
                       // Illegal empty exponent.
                       abort();
@@ -842,7 +842,7 @@
             // because its `Object#hasOwnProperty` implementation returns `false`
             // for array indices (e.g., `![1, 2, 3].hasOwnProperty("0")`).
             if (getClass.call(value) == arrayClass) {
-              for (length = value.length; length--; update(value, length, callback));
+              for (length = value.length; length--; update(value, length, callback)){}
             } else {
               forOwn(value, function (property) {
                 update(value, property, callback);


### PR DESCRIPTION
This fixes the `JSC_SUSPICIOUS_SEMICOLON` warning when using Google closure on the file.

`WARNING - If this if/for/while really shouldnt have a body, use {}`
